### PR TITLE
Add cinema app serializers, views, and urls

### DIFF
--- a/cinema/serializers.py
+++ b/cinema/serializers.py
@@ -1,1 +1,129 @@
-# write serializers here
+from rest_framework import (
+    serializers,
+)
+
+from .models import Actor, Genre, CinemaHall, Movie, MovieSession
+
+
+class GenreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Genre
+        fields = ("id", "name")
+
+
+class ActorSerializer(serializers.ModelSerializer):
+    full_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Actor
+        fields = ("id", "first_name", "last_name", "full_name")
+
+    def get_full_name(self, obj):
+        return f"{obj.first_name} {obj.last_name}"
+
+
+class CinemaHallSerializer(serializers.ModelSerializer):
+    capacity = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = CinemaHall
+        fields = ("id", "name", "rows", "seats_in_row", "capacity")
+
+
+# Movie serializers
+class MovieListSerializer(serializers.ModelSerializer):
+    genres = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field="name",
+    )
+    actors = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Movie
+        fields = (
+            "id",
+            "title",
+            "description",
+            "duration",
+            "genres",
+            "actors",
+        )
+
+    def get_actors(self, obj):
+        return [f"{actor.first_name} {actor.last_name}" for actor in obj.actors.all()]
+
+
+class MovieDetailSerializer(serializers.ModelSerializer):
+    genres = GenreSerializer(many=True, read_only=True)
+    actors = ActorSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Movie
+        fields = (
+            "id",
+            "title",
+            "description",
+            "duration",
+            "genres",
+            "actors",
+        )
+
+
+class MovieSerializer(serializers.ModelSerializer):
+    # базовий серіалізатор для створення/оновлення
+    class Meta:
+        model = Movie
+        fields = (
+            "id",
+            "title",
+            "description",
+            "duration",
+            "genres",
+            "actors",
+        )
+
+
+# MovieSession serializers
+class MovieSessionListSerializer(serializers.ModelSerializer):
+    movie_title = serializers.CharField(source="movie.title", read_only=True)
+    cinema_hall_name = serializers.CharField(source="cinema_hall.name", read_only=True)
+    cinema_hall_capacity = serializers.IntegerField(
+        source="cinema_hall.capacity", read_only=True
+    )
+
+    class Meta:
+        model = MovieSession
+        fields = (
+            "id",
+            "show_time",
+            "movie_title",
+            "cinema_hall_name",
+            "cinema_hall_capacity",
+        )
+
+
+class MovieSessionDetailSerializer(serializers.ModelSerializer):
+    movie = MovieListSerializer(read_only=True)
+    cinema_hall = CinemaHallSerializer(read_only=True)
+
+    class Meta:
+        model = MovieSession
+        fields = (
+            "id",
+            "show_time",
+            "movie",
+            "cinema_hall",
+        )
+
+
+class MovieSessionSerializer(serializers.ModelSerializer):
+    # базовий серіалізатор для створення/оновлення
+    class Meta:
+        model = MovieSession
+        fields = (
+            "id",
+            "show_time",
+            "movie",
+            "cinema_hall",
+        )

--- a/cinema/serializers.py
+++ b/cinema/serializers.py
@@ -15,7 +15,7 @@ class ActorSerializer(serializers.ModelSerializer):
         model = Actor
         fields = ("id", "first_name", "last_name", "full_name")
 
-    def get_full_name(self, obj):
+    def get_full_name(self, obj: Actor) -> str:
         return f"{obj.first_name} {obj.last_name}"
 
 
@@ -46,7 +46,7 @@ class MovieListSerializer(serializers.ModelSerializer):
             "actors",
         )
 
-    def get_actors(self, obj):
+    def get_actors(self, obj: Movie) -> list[str]:
         return [
             f"{actor.first_name} {actor.last_name}"
             for actor in obj.actors.all()

--- a/cinema/serializers.py
+++ b/cinema/serializers.py
@@ -1,7 +1,4 @@
-from rest_framework import (
-    serializers,
-)
-
+from rest_framework import serializers
 from .models import Actor, Genre, CinemaHall, Movie, MovieSession
 
 
@@ -30,7 +27,6 @@ class CinemaHallSerializer(serializers.ModelSerializer):
         fields = ("id", "name", "rows", "seats_in_row", "capacity")
 
 
-# Movie serializers
 class MovieListSerializer(serializers.ModelSerializer):
     genres = serializers.SlugRelatedField(
         many=True,
@@ -51,7 +47,10 @@ class MovieListSerializer(serializers.ModelSerializer):
         )
 
     def get_actors(self, obj):
-        return [f"{actor.first_name} {actor.last_name}" for actor in obj.actors.all()]
+        return [
+            f"{actor.first_name} {actor.last_name}"
+            for actor in obj.actors.all()
+        ]
 
 
 class MovieDetailSerializer(serializers.ModelSerializer):
@@ -71,7 +70,6 @@ class MovieDetailSerializer(serializers.ModelSerializer):
 
 
 class MovieSerializer(serializers.ModelSerializer):
-    # базовий серіалізатор для створення/оновлення
     class Meta:
         model = Movie
         fields = (
@@ -84,12 +82,18 @@ class MovieSerializer(serializers.ModelSerializer):
         )
 
 
-# MovieSession serializers
 class MovieSessionListSerializer(serializers.ModelSerializer):
-    movie_title = serializers.CharField(source="movie.title", read_only=True)
-    cinema_hall_name = serializers.CharField(source="cinema_hall.name", read_only=True)
+    movie_title = serializers.CharField(
+        source="movie.title",
+        read_only=True,
+    )
+    cinema_hall_name = serializers.CharField(
+        source="cinema_hall.name",
+        read_only=True,
+    )
     cinema_hall_capacity = serializers.IntegerField(
-        source="cinema_hall.capacity", read_only=True
+        source="cinema_hall.capacity",
+        read_only=True,
     )
 
     class Meta:
@@ -118,7 +122,6 @@ class MovieSessionDetailSerializer(serializers.ModelSerializer):
 
 
 class MovieSessionSerializer(serializers.ModelSerializer):
-    # базовий серіалізатор для створення/оновлення
     class Meta:
         model = MovieSession
         fields = (

--- a/cinema/urls.py
+++ b/cinema/urls.py
@@ -1,1 +1,23 @@
-# write urls here
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+
+from .views import (
+    GenreViewSet,
+    ActorViewSet,
+    CinemaHallViewSet,
+    MovieViewSet,
+    MovieSessionViewSet,
+)
+
+router = DefaultRouter()
+router.register("genres", GenreViewSet, basename="genre")
+router.register("actors", ActorViewSet, basename="actor")
+router.register("cinema_halls", CinemaHallViewSet, basename="cinema_hall")
+router.register("movies", MovieViewSet, basename="movie")
+router.register("movie_sessions", MovieSessionViewSet, basename="movie_session")
+
+urlpatterns = [
+    path("api/cinema/", include(router.urls)),
+]
+
+app_name = "cinema"

--- a/cinema/urls.py
+++ b/cinema/urls.py
@@ -12,6 +12,10 @@ router.register("genres", GenreViewSet, basename="genre")
 router.register("actors", ActorViewSet, basename="actor")
 router.register("cinema_halls", CinemaHallViewSet, basename="cinema_hall")
 router.register("movies", MovieViewSet, basename="movie")
-router.register("movie_sessions", MovieSessionViewSet, basename="movie_session")
+router.register(
+    "movie_sessions",
+    MovieSessionViewSet,
+    basename="movie_session",
+)
 
-urlpatterns = router.urls  # ✅ без додаткового path()
+urlpatterns = router.urls

--- a/cinema/urls.py
+++ b/cinema/urls.py
@@ -1,6 +1,4 @@
-from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-
 from .views import (
     GenreViewSet,
     ActorViewSet,
@@ -16,8 +14,4 @@ router.register("cinema_halls", CinemaHallViewSet, basename="cinema_hall")
 router.register("movies", MovieViewSet, basename="movie")
 router.register("movie_sessions", MovieSessionViewSet, basename="movie_session")
 
-urlpatterns = [
-    path("api/cinema/", include(router.urls)),
-]
-
-app_name = "cinema"
+urlpatterns = router.urls  # ✅ без додаткового path()

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -1,1 +1,53 @@
-# write views here
+from rest_framework import (
+    viewsets,
+)
+
+from .models import Genre, Actor, CinemaHall, Movie, MovieSession
+from .serializers import (
+    GenreSerializer,
+    ActorSerializer,
+    CinemaHallSerializer,
+    MovieSerializer,
+    MovieListSerializer,
+    MovieDetailSerializer,
+    MovieSessionSerializer,
+    MovieSessionListSerializer,
+    MovieSessionDetailSerializer,
+)
+
+
+class GenreViewSet(viewsets.ModelViewSet):
+    queryset = Genre.objects.all()
+    serializer_class = GenreSerializer
+
+
+class ActorViewSet(viewsets.ModelViewSet):
+    queryset = Actor.objects.all()
+    serializer_class = ActorSerializer
+
+
+class CinemaHallViewSet(viewsets.ModelViewSet):
+    queryset = CinemaHall.objects.all()
+    serializer_class = CinemaHallSerializer
+
+
+class MovieViewSet(viewsets.ModelViewSet):
+    queryset = Movie.objects.all()
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return MovieListSerializer
+        if self.action == "retrieve":
+            return MovieDetailSerializer
+        return MovieSerializer
+
+
+class MovieSessionViewSet(viewsets.ModelViewSet):
+    queryset = MovieSession.objects.all()
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return MovieSessionListSerializer
+        if self.action == "retrieve":
+            return MovieSessionDetailSerializer
+        return MovieSessionSerializer

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -1,7 +1,4 @@
-from rest_framework import (
-    viewsets,
-)
-
+from rest_framework import viewsets
 from .models import Genre, Actor, CinemaHall, Movie, MovieSession
 from .serializers import (
     GenreSerializer,
@@ -32,9 +29,9 @@ class CinemaHallViewSet(viewsets.ModelViewSet):
 
 
 class MovieViewSet(viewsets.ModelViewSet):
-    queryset = Movie.objects.all()
+    queryset = Movie.objects.prefetch_related("genres", "actors")
 
-    def get_serializer_class(self):
+    def get_serializer_class(self) -> type[MovieSerializer]:
         if self.action == "list":
             return MovieListSerializer
         if self.action == "retrieve":
@@ -43,9 +40,13 @@ class MovieViewSet(viewsets.ModelViewSet):
 
 
 class MovieSessionViewSet(viewsets.ModelViewSet):
-    queryset = MovieSession.objects.all()
+    queryset = (
+        MovieSession.objects
+        .select_related("movie", "cinema_hall")
+        .prefetch_related("movie__genres", "movie__actors")
+    )
 
-    def get_serializer_class(self):
+    def get_serializer_class(self) -> type[MovieSessionSerializer]:
         if self.action == "list":
             return MovieSessionListSerializer
         if self.action == "retrieve":

--- a/cinema_service/urls.py
+++ b/cinema_service/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/cinema/", include("cinema.urls")),  # ✅ єдиний префікс
 ]


### PR DESCRIPTION
Implemented serializers, views, and routing for the cinema app.
- Added serializers for Genre, Actor, CinemaHall, Movie, and MovieSession
- Custom list/detail serializers for Movie and MovieSession
- Configured ModelViewSets with dynamic serializer selection
- Registered routes via DefaultRouter and integrated into project urls
- All tests (31) passed successfully
